### PR TITLE
Remove redundant make args

### DIFF
--- a/labs/lab00-hello-world/Makefile
+++ b/labs/lab00-hello-world/Makefile
@@ -2,7 +2,5 @@ CHANNEL=Unstable
 
 release:
 	@replicated release create \
-		--app ${REPLICATED_APP} \
-		--token ${REPLICATED_API_TOKEN} \
 		--auto -y \
 		--promote $(CHANNEL)


### PR DESCRIPTION
Since we already have the app id and api token in the environment the app and token are redundant